### PR TITLE
add `toPx()` function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -149,8 +149,9 @@ I have provided a few other helper methods to make finding certain values more s
 ### Get font-sizes
 The `ds.fontSize()` method is a short-hand for the `ds.get()` method. It can be used to get a breakpoint from the `type.sizes` object.
 ```js
-ds.fontSize('xl') // 45 - we are using modular-scale to calculate sizes
-ds.fs('xl') // same as above 45 - we are using modular-scale to calculate sizes
+ds.fontSize('xl')
+ds.fs('xl') // `fs()` is a short-hand alias for `fontSize()`
+ds.fs('xl', true) // return font-size in px regardless of `option.fontSizeUnit` value
 ```
 
 ### Color palette

--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,13 @@ ds.pxTo(12, 20, 'rem') // 0.6rem
 ds.pxTo(12, 20, 'em') // 0.6em
 ```
 
+#### `toPx`
+Converts `rem` or `em` value to `px`
+```js
+ds.toPx('1.875rem', 16) // 30px
+ds.toPx('1.875em', 16) // 30px
+```
+
 ## Demo & examples
 I created a demo on [codesandbox.io](https://codesandbox.io/s/91kjlxnm0p), it includes examples of using the design-system utils with [emotion](https://emotion.sh/), [styled-components](https://www.styled-components.com/) and [glamorous](https://glamorous.rocks). There is also a basic example [here](example/).
 

--- a/src/calcs.js
+++ b/src/calcs.js
@@ -24,3 +24,16 @@ export const multiply = (initial, multiplier) => {
 export const pxTo = (value, base = 20, unit = 'rem') => {
   return `${value / base}${unit}`
 }
+
+/**
+ * @module toPx
+ * @description converts a `rem` or `em` value to `px`
+ * @author Zander
+ * @param {string} value
+ * @param {number} base
+ * @return {string}
+ * @example: toPx(30, 16)
+ */
+export const toPx = (value, base = 20) => {
+  return `${parseFloat(value) * base}px`
+}

--- a/src/calcs.test.js
+++ b/src/calcs.test.js
@@ -1,4 +1,4 @@
-import { multiply, pxTo } from './calcs'
+import { multiply, pxTo, toPx } from './calcs'
 
 test('multiply', () => {
   expect(multiply(10, 2)).toBe(20)
@@ -9,4 +9,10 @@ test(`pxTo`, () => {
   expect(pxTo(30, 16, 'em')).toBe('1.875em')
   expect(pxTo(30, 16, 'rem')).toBe('1.875rem')
   expect(pxTo(30, 16, 'px')).toBe('1.875px')
+})
+
+test(`toPx`, () => {
+  expect(toPx('1.875em', 16)).toBe('30px')
+  expect(toPx('1.875em')).toBe('37.5px')
+  expect(toPx('1.875rem', 16)).toBe('30px')
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import color from './color'
 import get from './get'
-import { multiply, pxTo } from './calcs'
+import { multiply, pxTo, toPx } from './calcs'
 import ms from 'modularscale-js'
 
 export default class DesignSystem {
@@ -15,6 +15,7 @@ export default class DesignSystem {
     this.color = color(system.colorPalette)
     this.multiply = multiply
     this.pxTo = pxTo
+    this.toPx = toPx
   }
 
   get(val) {

--- a/src/index.js
+++ b/src/index.js
@@ -30,13 +30,19 @@ export default class DesignSystem {
     return get(this.designSystem.zIndex, z)
   }
 
-  fontSize(size) {
+  fontSize(size, toPxl = false) {
     const value = get(this.designSystem.type.sizes, size)
     let output
     if (this.options.useModularScale) {
       output = ms(value, this.designSystem.type.modularscale)
     } else {
       output = value
+    }
+
+    const untransformedOutput = `${output}px`
+
+    if (toPxl) {
+      return untransformedOutput
     }
 
     switch (this.options.fontSizeUnit) {
@@ -53,12 +59,12 @@ export default class DesignSystem {
           'em'
         )
       default:
-        return `${output}px`
+        return untransformedOutput
     }
   }
 
-  fs(size) {
-    return this.fontSize(size)
+  fs(size, toPxl = false) {
+    return this.fontSize(size, toPxl)
   }
 
   spacing(index = 0) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -26,15 +26,18 @@ test('font-size - ds', () => {
 })
 
 test('font-size - ds1', () => {
-  expect(ds1.fs('base')).toBe('30px')
+  expect(ds1.fontSize('base')).toBe('30px')
+  expect(ds1.fontSize('base', true)).toBe('30px')
 })
 
 test('font-size - ds2', () => {
   expect(ds2.fs('m')).toBe('45px')
+  expect(ds2.fs('m', true)).toBe('45px')
 })
 
 test('font-size - ds3', () => {
   expect(ds3.fs('m')).toBe('1.5em')
+  expect(ds3.fs('m', true)).toBe('45px')
 })
 
 test('misc', () => {


### PR DESCRIPTION
Addresses two parts of #4:
- have a function that can convert `em`/`rem` values into `px`
- allow the `ds.fontSize()` method to return `px` values regardless of `options.fontSizeUnit` by adding a new parameter

e.g.
```
ds1.fontSize('base', true)
```