### PR TITLE
update multiply function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,7 +206,13 @@ The framework currently provides a few calculation functions, `multiply` and `px
 #### `multiply`
 ```js
 ds.multiply(10, 2) // 20
+
+// you can pass in another value from the system
 ds.multiply(ds.get('spacing.baseline'), 2)
+
+// or just use the key from the system
+// the initial value will always be run through `parseFloat()`
+ds.multiply('spacing.baseline', 2)
 ```
 
 #### `pxTo`

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import color from './color'
 import get from './get'
-import { multiply, pxTo, toPx } from './calcs'
+import { multiply as multi, pxTo, toPx } from './calcs'
 import ms from 'modularscale-js'
 
 export default class DesignSystem {
@@ -13,9 +13,18 @@ export default class DesignSystem {
     this.options = Object.assign({}, defaultOptions, options)
     this.designSystem = system
     this.color = color(system.colorPalette)
-    this.multiply = multiply
     this.pxTo = pxTo
     this.toPx = toPx
+  }
+
+  multiply(initial, multiplier) {
+    let initialVal
+    if (typeof initial === 'string') {
+      initialVal = parseFloat(this.get(initial))
+    } else {
+      initialVal = initial
+    }
+    return multi(initialVal, multiplier)
   }
 
   get(val) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -40,8 +40,14 @@ test('font-size - ds3', () => {
   expect(ds3.fs('m', true)).toBe('45px')
 })
 
-test('misc', () => {
+test('get', () => {
   expect(ds.get('type.baseFontSize')).toBe('20px')
   expect(ds1.get('type.baseFontSize')).toBe('30px')
   expect(ds2.get('type.baseFontSize')).toBe('30px')
+})
+
+test('ds.multiply', () => {
+  expect(ds.multiply(20, 2)).toBe(40)
+  expect(ds.multiply('type.baseFontSize', 2)).toBe(40)
+  expect(ds.multiply('spacing.baseline', 2)).toBe(40)
 })


### PR DESCRIPTION
`ds.multiply()` can now accept a key from your design system

e.g. `ds.multiply('spacing.baseline', 2)`