### PR TITLE
allow numbers to set font-size when using modular scale

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,7 @@ The `ds.fontSize()` method is a short-hand for the `ds.get()` method. It can be 
 ds.fontSize('xl')
 ds.fs('xl') // `fs()` is a short-hand alias for `fontSize()`
 ds.fs('xl', true) // return font-size in px regardless of `option.fontSizeUnit` value
+ds.fs(6) // returns font-size of the 6th item on the modular-scale. This will only work if the òptions.modularscale` is `true`
 ```
 
 ### Color palette

--- a/src/index.js
+++ b/src/index.js
@@ -40,12 +40,15 @@ export default class DesignSystem {
   }
 
   fontSize(size, toPxl = false) {
-    const value = get(this.designSystem.type.sizes, size)
     let output
     if (this.options.useModularScale) {
+      const value =
+        typeof size === 'number'
+          ? size
+          : get(this.designSystem.type.sizes, size)
       output = ms(value, this.designSystem.type.modularscale)
     } else {
-      output = value
+      output = get(this.designSystem.type.sizes, size)
     }
 
     const untransformedOutput = `${output}px`

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -22,7 +22,9 @@ test('spacing', () => {
 
 test('font-size - ds', () => {
   expect(ds.fs('base')).toBe('1rem')
+  expect(ds.fs(0)).toBe('1rem')
   expect(ds.fs('m')).toBe('1.5rem')
+  expect(ds.fs(1)).toBe('1.5rem')
 })
 
 test('font-size - ds1', () => {


### PR DESCRIPTION
this allows users to set type to any value on the modular scale, not just the ones provided in the design-system